### PR TITLE
proper camelCase for fn name and whitespace

### DIFF
--- a/plotters.R
+++ b/plotters.R
@@ -255,6 +255,7 @@ lineOPA <- function(data, x, y, title = "Title!", group = 1, percent = FALSE, cu
 
   return(base)
 }
+
 barOPA <- function(data, x, y, title = "Title", stat = "identity", position = "identity", percent = FALSE, currency = FALSE, ...) {
   # set fill with `fill = "variable"` if you have multiple groups
   # set y-axis label with `ylab = "label"`
@@ -264,11 +265,7 @@ barOPA <- function(data, x, y, title = "Title", stat = "identity", position = "i
   dots <- eval(substitute(alist(...)))
 
   #get max y value and set breaks
-  if( !is.null(dots$fill) ) {
-	ytots <- aggregate(data[y],data[x],sum)
-    ymax <- max(ytots[y])
-  }
-  else{ymax <- max(data[y], na.rm = TRUE)}
+  ymax <- max(data[y], na.rm = TRUE)
   brks <- pretty_breaks(4, min.n = 4)(0:ymax)
   yul  <- brks[length(brks)]
 


### PR DESCRIPTION
I just cleaned up the indentation and spacing a bit so this function is more readable and consistent. Seems pedantic, but I think having consistent indentation and other stylistic conventions helps newcomers to the code (and to code more generally) understand what's going on. 

More importantly, I renamed mapOPApoints to mapOPAPoints just to use the proper camelCase convention. You can reject this if it'll break your dependent scripts.
